### PR TITLE
Pagination

### DIFF
--- a/src/main/java/com/beaconstrategists/taccaseapiservice/config/api/JacksonConfig.java
+++ b/src/main/java/com/beaconstrategists/taccaseapiservice/config/api/JacksonConfig.java
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.Primary;
 @Configuration
 public class JacksonConfig {
 
-    @Value("${ESCAPE_HTML_STRINGS:true}")
+    @Value("${ESCAPE_HTML_STRINGS:false}")
     private String escapeHtmlStrings;
 
 

--- a/src/main/java/com/beaconstrategists/taccaseapiservice/controllers/RmaCaseController.java
+++ b/src/main/java/com/beaconstrategists/taccaseapiservice/controllers/RmaCaseController.java
@@ -5,12 +5,9 @@ import com.beaconstrategists.taccaseapiservice.exceptions.ResourceNotFoundExcept
 import com.beaconstrategists.taccaseapiservice.model.CaseStatus;
 import com.beaconstrategists.taccaseapiservice.services.RmaCaseService;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.core.io.Resource;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,6 +23,13 @@ import static org.springframework.shell.command.invocation.InvocableShellMethod.
 public class RmaCaseController {
 
     private final RmaCaseService rmaCaseService;
+
+    @Value("${FD_DEFAULT_PAGE_SIZE:100}")
+    private Integer defaultPageSize;
+
+    @Value("${FD_DEFAULT_PAGE_LIMIT:1000}")
+    private Integer defaultPageLimit;
+
 
     public RmaCaseController(RmaCaseService rmaCaseService) {
         this.rmaCaseService = rmaCaseService;
@@ -49,7 +53,20 @@ public class RmaCaseController {
             List<CaseStatus> caseStatus,
 
             @RequestParam(required = false, defaultValue = "AND")
-            String logic) {
+            String logic,
+
+            @RequestParam(required = false, defaultValue = "100")
+            Integer pageSize,
+
+            @RequestParam(required = false, defaultValue = "100")
+            Integer pageLimit) {
+
+        if (pageSize == null) {
+            pageSize = defaultPageSize;
+        }
+        if (pageLimit == null) {
+            pageLimit = defaultPageLimit;
+        }
 
         if (caseCreateDateFrom != null && caseCreateDateTo != null) {
             if (caseCreateDateFrom.isAfter(caseCreateDateTo)) {
@@ -62,7 +79,9 @@ public class RmaCaseController {
                 caseCreateDateTo,
                 caseCreateDateSince,
                 caseStatus,
-                logic);
+                logic,
+                pageSize,
+                pageLimit);
 
         return new ResponseEntity<>(rmaCases, HttpStatus.OK);
     }

--- a/src/main/java/com/beaconstrategists/taccaseapiservice/controllers/TacCaseController.java
+++ b/src/main/java/com/beaconstrategists/taccaseapiservice/controllers/TacCaseController.java
@@ -5,6 +5,7 @@ import com.beaconstrategists.taccaseapiservice.exceptions.ResourceNotFoundExcept
 import com.beaconstrategists.taccaseapiservice.model.CaseStatus;
 import com.beaconstrategists.taccaseapiservice.services.TacCaseService;
 import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,7 +13,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,6 +21,12 @@ import java.util.Optional;
 public class TacCaseController {
 
     private final TacCaseService tacCaseService;
+
+    @Value("${FD_DEFAULT_PAGE_SIZE:100}")
+    private Integer defaultPageSize;
+
+    @Value("${FD_DEFAULT_PAGE_LIMIT:1000}")
+    private Integer defaultPageLimit;
 
     public TacCaseController(TacCaseService tacCaseService) {
         this.tacCaseService = tacCaseService;
@@ -44,7 +50,20 @@ public class TacCaseController {
             List<CaseStatus> caseStatus,
 
             @RequestParam(required = false, defaultValue = "AND")
-            String logic) {
+            String logic,
+
+            @RequestParam(required = false)
+            Integer pageSize,
+
+            @RequestParam(required = false)
+            Integer pageLimit) {
+
+        if (pageSize == null) {
+            pageSize = defaultPageSize;
+        }
+        if (pageLimit == null) {
+            pageLimit = defaultPageLimit;
+        }
 
         if (caseCreateDateFrom != null && caseCreateDateTo != null) {
             if (caseCreateDateFrom.isAfter(caseCreateDateTo)) {
@@ -57,7 +76,9 @@ public class TacCaseController {
                 caseCreateDateTo,
                 caseCreateDateSince,
                 caseStatus,
-                logic
+                logic,
+                pageSize,
+                pageLimit
         );
         return new ResponseEntity<>(tacCases, HttpStatus.OK);
     }

--- a/src/main/java/com/beaconstrategists/taccaseapiservice/dtos/freshdesk/FreshdeskLinksDto.java
+++ b/src/main/java/com/beaconstrategists/taccaseapiservice/dtos/freshdesk/FreshdeskLinksDto.java
@@ -18,6 +18,9 @@ public class FreshdeskLinksDto {
     @JsonProperty("count")
     private Link count;
 
+    @JsonProperty("prev")
+    private Link prev;
+
     @Getter
     @Setter
     @NoArgsConstructor

--- a/src/main/java/com/beaconstrategists/taccaseapiservice/dtos/freshdesk/FreshdeskLinksDto.java
+++ b/src/main/java/com/beaconstrategists/taccaseapiservice/dtos/freshdesk/FreshdeskLinksDto.java
@@ -6,17 +6,24 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.List;
-
 @Getter
 @Setter
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class FreshdeskCaseResponseRecords<T> {
+public class FreshdeskLinksDto {
 
-    private List<FreshdeskCaseResponse<T>> records;
+    @JsonProperty("next")
+    private Link next;
 
-    @JsonProperty("_links")
-    private FreshdeskLinksDto links;  // Add this field to support `_links` in the response
+    @JsonProperty("count")
+    private Link count;
 
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Link {
+        @JsonProperty("href")
+        private String href;
+    }
 }

--- a/src/main/java/com/beaconstrategists/taccaseapiservice/services/RmaCaseService.java
+++ b/src/main/java/com/beaconstrategists/taccaseapiservice/services/RmaCaseService.java
@@ -21,7 +21,9 @@ public interface RmaCaseService {
                                           OffsetDateTime caseCreateDateTo,
                                           OffsetDateTime caseCreateDateSince,
                                           List<CaseStatus> caseStatus,
-                                          String logic);
+                                          String logic,
+                                          Integer pageSize,
+                                          Integer pageLimit);
 
     List<RmaCaseResponseDto> findAll();
 

--- a/src/main/java/com/beaconstrategists/taccaseapiservice/services/TacCaseService.java
+++ b/src/main/java/com/beaconstrategists/taccaseapiservice/services/TacCaseService.java
@@ -21,7 +21,9 @@ public interface TacCaseService {
                                           OffsetDateTime caseCreateDateTo,
                                           OffsetDateTime caseCreateDateSince,
                                           List<CaseStatus> caseStatus,
-                                          String logic);
+                                          String logic,
+                                          Integer pageSize,
+                                          Integer pageLimit);
 
     List<TacCaseResponseDto> findAll();
 

--- a/src/main/java/com/beaconstrategists/taccaseapiservice/services/freshdesk/impl/FreshDeskTacCaseService.java
+++ b/src/main/java/com/beaconstrategists/taccaseapiservice/services/freshdesk/impl/FreshDeskTacCaseService.java
@@ -84,6 +84,7 @@ public class FreshDeskTacCaseService implements TacCaseService {
 
         // Build the query parameters dynamically
         UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.newInstance();
+        uriComponentsBuilder.queryParam("page_size", 50);
 
         if (caseCreateDateFrom != null && caseCreateDateTo != null) {
             uriComponentsBuilder.queryParam("created_time[gt]", caseCreateDateFrom.format(formatter))

--- a/src/main/java/com/beaconstrategists/taccaseapiservice/services/impl/RmaCaseServiceImpl.java
+++ b/src/main/java/com/beaconstrategists/taccaseapiservice/services/impl/RmaCaseServiceImpl.java
@@ -127,7 +127,9 @@ public class RmaCaseServiceImpl implements RmaCaseService {
                                                  OffsetDateTime caseCreateDateTo,
                                                  OffsetDateTime caseCreateDateSince,
                                                  List<CaseStatus> caseStatus,
-                                                 String logic) {
+                                                 String logic,
+                                                 Integer pageSize,
+                                                 Integer pageLimit) {
 
         Specification<RmaCaseEntity> specification = RmaCaseSpecification.buildSpecification(
                 caseCreateDateFrom,
@@ -140,6 +142,7 @@ public class RmaCaseServiceImpl implements RmaCaseService {
         List<RmaCaseEntity> rmaCases = rmaCaseRepository.findAll(specification);
 
         return rmaCases.stream()
+                .limit((long) pageSize *pageLimit)
                 .map(rmaCaseMapper::mapTo)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/beaconstrategists/taccaseapiservice/services/impl/TacCaseServiceImpl.java
+++ b/src/main/java/com/beaconstrategists/taccaseapiservice/services/impl/TacCaseServiceImpl.java
@@ -128,7 +128,9 @@ public class TacCaseServiceImpl implements TacCaseService {
             OffsetDateTime caseCreateDateTo,
             OffsetDateTime caseCreateDateSince,
             List<CaseStatus> caseStatus,
-            String logic) {
+            String logic,
+            Integer pageSize,
+            Integer pageLimit) {
 
         Specification<TacCaseEntity> specification = TacCaseSpecification.buildSpecification(
                 caseCreateDateFrom,
@@ -141,6 +143,7 @@ public class TacCaseServiceImpl implements TacCaseService {
         List<TacCaseEntity> tacCases = tacCaseRepository.findAll(specification);
 
         return tacCases.stream()
+                .limit((long) pageSize * pageLimit)
                 .map(tacCaseMapper::mapTo)
                 .collect(Collectors.toList());
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,4 +47,4 @@ logging:
   level:
     root: warn
     org.springframework: warn
-    com.beaconstrategists: debug
+    com.beaconstrategists: warn


### PR DESCRIPTION
This solution adds two new query parameters to the endpoints that list all cases. The new query parameters are: pageSize and pageLimit. If they are not passed, the default values are 100 and 1000 respectively. This will default the maximum number of Cases returned to 10,000. Probably not a good default but we'll start there. These default values can be changed by setting environment variables: FD_DEFAULT_PAGE_SIZE, FD_DEFAULT_PAGE_LIMIT

examples:
10,000 Cases: /api/v1/tacCases
1,000 Cases: /api/v1/tacCases?pageSize=100&pageLimit=10
1,000 Cases: /api/v1/tacCases?pageSize=10&pageLimit=100

Freshdesk sets a max page size of 100.
Performance will be better with a larger page size
I considered just dropped these in favor of a single query parameter called "caseLimit" where we default to a pageSize of 100 but these will be useful when testing and when working with a Sandbox or a lower end Freshdesk plan like the Growth Plan.
Commit: 557373e